### PR TITLE
feat: add custom player with cover

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,12 +156,22 @@
         <section>
           <h2>Playlist (Spotify)</h2>
           <p class="note">lagu favorit ku, yang sering ku putar.</p>
-          <audio
-            id="song-player"
-            controls
-            preload="auto"
-            src="letdown.mp3"
-          ></audio>
+          <div class="music-player">
+            <img
+              class="music-cover"
+              src="https://image-cdn-ak.spotifycdn.com/image/ab67616d00001e0205898628baab6ef07a0a4d03"
+              alt="Sampul Spotify letdown"
+            />
+            <div class="music-info">
+              <h3 class="music-title">letdown — Hindia</h3>
+              <audio
+                id="song-player"
+                controls
+                preload="auto"
+                src="letdown.mp3"
+              ></audio>
+            </div>
+          </div>
           <div class="grid2">
             <div class="playlist-embed">
               <iframe

--- a/styles.css
+++ b/styles.css
@@ -68,6 +68,38 @@ body {
   margin-top: -4px;
 }
 
+.music-player {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+  margin: 16px 0 24px;
+  background: #0b1324;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+}
+
+.music-cover {
+  width: 96px;
+  height: 96px;
+  border-radius: 12px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.music-info {
+  flex: 1;
+}
+
+.music-title {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+
+.music-info audio {
+  width: 100%;
+}
+
 header.hero {
   display: grid;
   gap: 18px;


### PR DESCRIPTION
## Summary
- add Spotify-style card for letdown track with local cover art
- style custom audio player for cleaner layout
- load cover art directly from Spotify to avoid bundling image files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b526d064c88333aeec794846e911a1