### PR TITLE
Add Spotify-style play button for playlist tracks

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,13 +164,13 @@
             />
             <div class="music-info">
               <h3 class="music-title">letdown — Hindia</h3>
-              <audio
-                id="song-player"
-                controls
-                preload="auto"
-                src="letdown.mp3"
-              ></audio>
+              <audio preload="auto" src="letdown.mp3"></audio>
             </div>
+            <button class="play-btn" aria-label="Putar">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path fill="currentColor" d="M8 5v14l11-7z" />
+              </svg>
+            </button>
           </div>
           <div class="music-player">
             <img
@@ -180,8 +180,13 @@
             />
             <div class="music-info">
               <h3 class="music-title">everything u are — Hindia</h3>
-              <audio controls preload="auto" src="everything-u-are-Hindia.mp3"></audio>
+              <audio preload="auto" src="everything-u-are-Hindia.mp3"></audio>
             </div>
+            <button class="play-btn" aria-label="Putar">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path fill="currentColor" d="M8 5v14l11-7z" />
+              </svg>
+            </button>
           </div>
         </section>
 
@@ -194,6 +199,37 @@
 
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
+      const playIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M8 5v14l11-7z"/></svg>';
+      const pauseIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M6 19h4V5H6zm8-14v14h4V5h-4z"/></svg>';
+      let currentAudio = null;
+      document.querySelectorAll('.music-player').forEach(player => {
+        const audio = player.querySelector('audio');
+        const btn = player.querySelector('.play-btn');
+        btn.addEventListener('click', () => {
+          if (audio.paused) {
+            if (currentAudio && currentAudio !== audio) {
+              currentAudio.pause();
+              const otherBtn = currentAudio.closest('.music-player').querySelector('.play-btn');
+              otherBtn.innerHTML = playIcon;
+              otherBtn.setAttribute('aria-label', 'Putar');
+            }
+            audio.play();
+            btn.innerHTML = pauseIcon;
+            btn.setAttribute('aria-label', 'Jeda');
+            currentAudio = audio;
+          } else {
+            audio.pause();
+            btn.innerHTML = playIcon;
+            btn.setAttribute('aria-label', 'Putar');
+            currentAudio = null;
+          }
+        });
+        audio.addEventListener('ended', () => {
+          btn.innerHTML = playIcon;
+          btn.setAttribute('aria-label', 'Putar');
+          if (currentAudio === audio) currentAudio = null;
+        });
+      });
     </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -97,7 +97,26 @@ body {
 }
 
 .music-info audio {
-  width: 100%;
+  display: none;
+}
+
+.play-btn {
+  width: 48px;
+  height: 48px;
+  border: none;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #0b1222;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.play-btn svg {
+  width: 24px;
+  height: 24px;
 }
 
 header.hero {


### PR DESCRIPTION
## Summary
- hide default `<audio>` controls and attach round play/pause buttons
- add JavaScript to toggle icons and ensure only one track plays at a time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b52d09be4c8333b4089a7c71e3c469