### PR TITLE
feat: redesign music player cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,37 +156,77 @@
         <section>
           <h2>Playlist</h2>
           <p class="note">lagu favorit ku, yang sering ku putar.</p>
+
           <div class="music-player">
-            <img
-              class="music-cover"
-              src="https://image-cdn-ak.spotifycdn.com/image/ab67616d00001e0205898628baab6ef07a0a4d03"
-              alt="Sampul album letdown"
-            />
-            <div class="music-info">
-              <h3 class="music-title">letdown — Hindia</h3>
-              <audio preload="auto" src="letdown.mp3"></audio>
+            <div class="album">
+              <img
+                class="music-cover"
+                src="https://image-cdn-ak.spotifycdn.com/image/ab67616d00001e0205898628baab6ef07a0a4d03"
+                alt="Sampul album letdown"
+              />
+              <span class="spotify-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    fill="currentColor"
+                    d="M12 0a12 12 0 1 0 0 24 12 12 0 0 0 0-24zm5.163 17.354a.75.75 0 0 1-1.036.249c-2.84-1.738-6.418-2.132-10.621-1.171a.75.75 0 1 1-.342-1.462c4.55-1.062 8.463-.611 11.584 1.287a.75.75 0 0 1 .415.835zm1.48-3.294a.94.94 0 0 1-1.302.31c-3.247-1.99-8.208-2.57-12.051-1.414a.94.94 0 1 1-.558-1.804c4.27-1.32 9.703-.67 13.468 1.58a.94.94 0 0 1 .443 1.328zm.131-3.408c-3.633-2.156-9.14-2.352-12.421-1.29a1.13 1.13 0 1 1-.668-2.162c4.043-1.25 10.2-1.012 14.35 1.455a1.13 1.13 0 0 1-1.261 1.997z"
+                  />
+                </svg>
+              </span>
+              <button class="play-btn" aria-label="Putar">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path fill="currentColor" d="M8 5v14l11-7z" />
+                </svg>
+              </button>
             </div>
-            <button class="play-btn" aria-label="Putar">
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path fill="currentColor" d="M8 5v14l11-7z" />
-              </svg>
-            </button>
+            <h3 class="music-title">letdown</h3>
+            <p class="music-artist">Hindia</p>
+            <div class="music-actions">
+              <span class="preview-tag">Preview</span>
+              <a
+                class="save-link"
+                href="https://open.spotify.com/search/letdown%20hindia"
+                target="_blank"
+                rel="noopener"
+                >Save on Spotify</a
+              >
+            </div>
+            <audio preload="auto" src="letdown.mp3"></audio>
           </div>
+
           <div class="music-player">
-            <img
-              class="music-cover"
-              src="https://image-cdn-ak.spotifycdn.com/image/ab67616d00001e0205898628baab6ef07a0a4d03"
-              alt="Sampul album everything u are"
-            />
-            <div class="music-info">
-              <h3 class="music-title">everything u are — Hindia</h3>
-              <audio preload="auto" src="everything-u-are-Hindia.mp3"></audio>
+            <div class="album">
+              <img
+                class="music-cover"
+                src="https://image-cdn-ak.spotifycdn.com/image/ab67616d00001e0205898628baab6ef07a0a4d03"
+                alt="Sampul album everything u are"
+              />
+              <span class="spotify-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    fill="currentColor"
+                    d="M12 0a12 12 0 1 0 0 24 12 12 0 0 0 0-24zm5.163 17.354a.75.75 0 0 1-1.036.249c-2.84-1.738-6.418-2.132-10.621-1.171a.75.75 0 1 1-.342-1.462c4.55-1.062 8.463-.611 11.584 1.287a.75.75 0 0 1 .415.835zm1.48-3.294a.94.94 0 0 1-1.302.31c-3.247-1.99-8.208-2.57-12.051-1.414a.94.94 0 1 1-.558-1.804c4.27-1.32 9.703-.67 13.468 1.58a.94.94 0 0 1 .443 1.328zm.131-3.408c-3.633-2.156-9.14-2.352-12.421-1.29a1.13 1.13 0 1 1-.668-2.162c4.043-1.25 10.2-1.012 14.35 1.455a1.13 1.13 0 0 1-1.261 1.997z"
+                  />
+                </svg>
+              </span>
+              <button class="play-btn" aria-label="Putar">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path fill="currentColor" d="M8 5v14l11-7z" />
+                </svg>
+              </button>
             </div>
-            <button class="play-btn" aria-label="Putar">
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path fill="currentColor" d="M8 5v14l11-7z" />
-              </svg>
-            </button>
+            <h3 class="music-title">everything u are</h3>
+            <p class="music-artist">Hindia</p>
+            <div class="music-actions">
+              <span class="preview-tag">Preview</span>
+              <a
+                class="save-link"
+                href="https://open.spotify.com/search/everything%20u%20are%20hindia"
+                target="_blank"
+                rel="noopener"
+                >Save on Spotify</a
+              >
+            </div>
+            <audio preload="auto" src="everything-u-are-Hindia.mp3"></audio>
           </div>
         </section>
 

--- a/styles.css
+++ b/styles.css
@@ -70,53 +70,103 @@ body {
 
 .music-player {
   display: flex;
-  align-items: center;
-  gap: 16px;
+  flex-direction: column;
   padding: 16px;
   margin: 16px 0 24px;
   background: #0b1324;
   border: 1px solid var(--line);
-  border-radius: 16px;
+  border-radius: 20px;
+}
+
+.album {
+  position: relative;
 }
 
 .music-cover {
-  width: 96px;
-  height: 96px;
-  border-radius: 12px;
+  width: 100%;
+  border-radius: 16px;
   object-fit: cover;
-  flex-shrink: 0;
 }
 
-.music-info {
-  flex: 1;
+.spotify-icon {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.music-title {
-  margin: 0 0 8px;
-  font-size: 1rem;
-}
-
-.music-info audio {
-  display: none;
+.spotify-icon svg {
+  width: 18px;
+  height: 18px;
+  fill: #fff;
 }
 
 .play-btn {
-  width: 48px;
-  height: 48px;
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  width: 64px;
+  height: 64px;
   border: none;
   border-radius: 50%;
-  background: var(--accent);
+  background: #fff;
   color: #0b1222;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  flex-shrink: 0;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
 }
 
 .play-btn svg {
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
+}
+
+.music-title {
+  margin: 16px 0 4px;
+  font-size: 1.1rem;
+}
+
+.music-artist {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.music-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.preview-tag {
+  border: 1px solid var(--line);
+  background: #0b1324;
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.save-link {
+  font-size: 0.85rem;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.save-link:hover {
+  text-decoration: underline;
+}
+
+.music-player audio {
+  display: none;
 }
 
 header.hero {


### PR DESCRIPTION
## Summary
- restyle playlist into large banner cards with album art, overlay play button, and save links
- add Spotify icon badges and preview labels for each track

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b530ddb2b48333981f521c6ca4c78d