### PR TITLE
Add gallery protections and shrink music player

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,6 +294,9 @@
             img.src = f.download_url;
             img.alt = f.name;
             img.loading = 'lazy';
+            img.draggable = false;
+            img.addEventListener('contextmenu', e => e.preventDefault());
+            img.addEventListener('dragstart', e => e.preventDefault());
             container.appendChild(img);
           });
         } catch (err) {
@@ -301,6 +304,22 @@
         }
       }
       loadGallery();
+
+      document.addEventListener('contextmenu', e => {
+        if (e.target.closest('#gallery')) {
+          e.preventDefault();
+        }
+      });
+
+      document.addEventListener('keydown', e => {
+        if (
+          e.key === 'F12' ||
+          (e.ctrlKey && e.shiftKey && ['I', 'J', 'C'].includes(e.key)) ||
+          (e.ctrlKey && ['S', 'U'].includes(e.key))
+        ) {
+          e.preventDefault();
+        }
+      });
     </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -98,6 +98,8 @@ body {
     background: #0b1324;
     border: 1px solid var(--line);
     border-radius: 20px;
+    max-width: 260px;
+    margin: 0 auto;
   }
 
 .album {
@@ -133,8 +135,8 @@ body {
   position: absolute;
   bottom: 16px;
   right: 16px;
-  width: 64px;
-  height: 64px;
+  width: 48px;
+  height: 48px;
   border: none;
   border-radius: 50%;
   background: #fff;
@@ -147,8 +149,8 @@ body {
 }
 
 .play-btn svg {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
 }
 
 .music-title {


### PR DESCRIPTION
## Summary
- prevent downloads in gallery and block developer tools shortcuts
- shrink music player and play button for a smaller footprint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b613f263348333b8eb296f9b888a0c