### PR TITLE
Switch Spotify streaming to FabDL (polling + cache) and fix gallery ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
               <div class="spotify-meta">
                 <p class="spotify-title">Favorit terbaru minggu ini</p>
                 <p class="spotify-note">
-                  Auto update dari SpotDL + cache ringan agar tetap cepat.
+                  Auto update dari FabDL + cache ringan agar tetap cepat.
                 </p>
               </div>
               <a
@@ -526,91 +526,113 @@
         '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M8 5v14l11-7z"/></svg>';
       const pauseIcon =
         '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M6 19h4V5H6zm8-14v14h4V5h-4z"/></svg>';
-      const SPOTDL_ENDPOINT = 'https://spotdl.zeabur.app/';
-      const SPOTDL_CACHE_KEY = 'spotdl-favorites-v1';
-      const SPOTDL_CACHE_TTL = 1000 * 60 * 60 * 24 * 7;
-      const spotdlRequests = new Map();
+      const FABDL_BASE_URL = 'https://api.fabdl.com';
+      const FABDL_CACHE_KEY = 'fabdl-favorites-v1';
+      const FABDL_CACHE_TTL = 1000 * 60 * 60 * 24 * 7;
+      const FABDL_POLL_INTERVAL = 1200;
+      const FABDL_POLL_ATTEMPTS = 6;
+      const fabdlRequests = new Map();
       let currentAudio = null;
 
-      function readSpotdlCache() {
+      function readFabdlCache() {
         try {
-          const raw = localStorage.getItem(SPOTDL_CACHE_KEY);
+          const raw = localStorage.getItem(FABDL_CACHE_KEY);
           return raw ? JSON.parse(raw) : {};
         } catch (error) {
-          console.warn('SpotDL cache reset', error);
+          console.warn('FabDL cache reset', error);
           return {};
         }
       }
 
-      const spotdlCache = readSpotdlCache();
+      const fabdlCache = readFabdlCache();
 
-      function persistSpotdlCache() {
+      function persistFabdlCache() {
         try {
-          localStorage.setItem(SPOTDL_CACHE_KEY, JSON.stringify(spotdlCache));
+          localStorage.setItem(FABDL_CACHE_KEY, JSON.stringify(fabdlCache));
         } catch (error) {
-          console.warn('SpotDL cache write failed', error);
+          console.warn('FabDL cache write failed', error);
         }
       }
 
       function getCachedTrack(spotifyUrl) {
-        const cached = spotdlCache[spotifyUrl];
+        const cached = fabdlCache[spotifyUrl];
         if (!cached) return null;
-        if (Date.now() - cached.fetchedAt > SPOTDL_CACHE_TTL) {
+        if (Date.now() - cached.fetchedAt > FABDL_CACHE_TTL) {
           return null;
         }
         return cached;
       }
 
       function updateTrackCache(spotifyUrl, data) {
-        spotdlCache[spotifyUrl] = { ...data, fetchedAt: Date.now() };
-        persistSpotdlCache();
+        fabdlCache[spotifyUrl] = { ...data, fetchedAt: Date.now() };
+        persistFabdlCache();
       }
 
-      function extractSpotdlThumbnail(html, doc) {
-        const metaImage = doc.querySelector('meta[property="og:image"]')?.content;
-        if (metaImage) return metaImage;
-        const matches = html.match(/https:\/\/i\.scdn\.co\/image\/[a-zA-Z0-9]+/g);
-        return matches ? matches[0] : null;
+      function delay(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
       }
 
-      function parseSpotdlTitle(doc) {
-        const titleText =
-          doc.querySelector('meta[property="og:title"]')?.content ||
-          doc.querySelector('title')?.textContent;
-        if (!titleText) return {};
-        if (titleText.includes(' - ')) {
-          const [title, artist] = titleText.split(' - ');
-          return { title: title.trim(), artist: artist.trim() };
+      async function fetchFabdlJson(path) {
+        const response = await fetch(`${FABDL_BASE_URL}${path}`, {
+          cache: 'no-store',
+        });
+        if (!response.ok) {
+          throw new Error(`FabDL error ${response.status}`);
         }
-        return { title: titleText.trim() };
+        return response.json();
       }
 
-      async function fetchSpotdlMetadata(spotifyUrl) {
-        if (spotdlRequests.has(spotifyUrl)) {
-          return spotdlRequests.get(spotifyUrl);
+      async function fetchFabdlMetadata(spotifyUrl) {
+        if (fabdlRequests.has(spotifyUrl)) {
+          return fabdlRequests.get(spotifyUrl);
         }
-        const request = fetch(
-          `${SPOTDL_ENDPOINT}?url=${encodeURIComponent(spotifyUrl)}&cache=${Date.now()}`,
-          { cache: 'no-store' }
-        )
-          .then(async response => {
-            if (!response.ok) {
-              throw new Error(`SpotDL error ${response.status}`);
-            }
-            const html = await response.text();
-            const doc = new DOMParser().parseFromString(html, 'text/html');
-            const source = doc.querySelector('source');
-            const thumbnailUrl = extractSpotdlThumbnail(html, doc);
-            return {
-              audioUrl: source?.src ?? '',
-              thumbnailUrl,
-              ...parseSpotdlTitle(doc),
-            };
-          })
-          .finally(() => {
-            spotdlRequests.delete(spotifyUrl);
-          });
-        spotdlRequests.set(spotifyUrl, request);
+
+        const request = (async () => {
+          const trackPayload = await fetchFabdlJson(
+            `/spotify/get?url=${encodeURIComponent(spotifyUrl)}`
+          );
+          const track = trackPayload?.result;
+          if (!track?.id || !track?.gid) {
+            throw new Error('FabDL track metadata kosong');
+          }
+
+          const taskPayload = await fetchFabdlJson(
+            `/spotify/mp3-convert-task/${track.gid}/${track.id}`
+          );
+          let task = taskPayload?.result;
+          if (!task?.tid) {
+            throw new Error('FabDL task belum siap');
+          }
+
+          let downloadUrl = task.download_url;
+          let status = task.status;
+
+          for (let attempt = 0; attempt < FABDL_POLL_ATTEMPTS; attempt += 1) {
+            if (status === 3 && downloadUrl) break;
+            await delay(FABDL_POLL_INTERVAL);
+            const progressPayload = await fetchFabdlJson(
+              `/spotify/mp3-convert-progress/${task.tid}`
+            );
+            task = progressPayload?.result ?? task;
+            status = task.status;
+            downloadUrl = task.download_url;
+          }
+
+          const audioUrl = downloadUrl
+            ? new URL(downloadUrl, FABDL_BASE_URL).toString()
+            : '';
+
+          return {
+            audioUrl,
+            thumbnailUrl: track.image,
+            title: track.name,
+            artist: track.artists,
+          };
+        })().finally(() => {
+          fabdlRequests.delete(spotifyUrl);
+        });
+
+        fabdlRequests.set(spotifyUrl, request);
         return request;
       }
 
@@ -664,12 +686,15 @@
         }
         setPlayerState(player, 'loading', 'Memuat...');
         try {
-          const data = await fetchSpotdlMetadata(spotifyUrl);
+          const data = await fetchFabdlMetadata(spotifyUrl);
           applyTrackMetadata(player, data);
           updateTrackCache(spotifyUrl, data);
+          if (!data.audioUrl) {
+            throw new Error('Audio belum siap');
+          }
           setPlayerState(player, 'ready', 'Streaming');
         } catch (error) {
-          console.error('Gagal memuat data SpotDL', error);
+          console.error('Gagal memuat data FabDL', error);
           setPlayerState(
             player,
             'error',
@@ -695,7 +720,11 @@
         const cached = getCachedTrack(player.dataset.spotifyUrl);
         if (cached) {
           applyTrackMetadata(player, cached);
-          setPlayerState(player, 'ready', 'Streaming');
+          if (cached.audioUrl) {
+            setPlayerState(player, 'ready', 'Streaming');
+          } else {
+            setPlayerState(player, 'loading', 'Memuat...');
+          }
         } else {
           setPlayerState(player, 'loading', 'Memuat...');
         }
@@ -761,7 +790,7 @@
       }
 
       async function loadGallery() {
-        const container = document.getElementById('galery');
+        const container = document.getElementById('gallery');
         if (!container) return;
 
         const { owner, repo } = resolveGalleryRepo(container);
@@ -819,7 +848,7 @@
       loadGallery();
 
       document.addEventListener('contextmenu', e => {
-        if (e.target.closest('#galery')) {
+        if (e.target.closest('#gallery')) {
           e.preventDefault();
         }
       });


### PR DESCRIPTION
### Motivation
- Replace the previous SpotDL HTML-parsing flow with the FabDL JSON API workflow to reliably obtain metadata and a downloadable audio URL. 
- Add polling and readiness checks so the UI only marks a track as "Streaming" when an audio URL is available. 
- Fix a typo in the gallery element id so lazy loading and context-menu prevention target the correct container.

### Description
- Replaced SpotDL constants and cache with FabDL equivalents (`FABDL_BASE_URL`, `FABDL_CACHE_KEY`, `FABDL_CACHE_TTL`) and renamed request map to `fabdlRequests`. 
- Implemented `fetchFabdlJson`, `fetchFabdlMetadata` and a small polling loop (`FABDL_POLL_INTERVAL`, `FABDL_POLL_ATTEMPTS`) to follow the FabDL flow: `/spotify/get` → `/spotify/mp3-convert-task` → `/spotify/mp3-convert-progress`, and build a proper `audioUrl`. 
- Added `delay` helper, updated cache read/write functions (`readFabdlCache`, `persistFabdlCache`), and changed caching keys and logic so cached entries that lack `audioUrl` are treated as not ready. 
- Updated UI handling to only set player to `is-ready` when `audioUrl` is present and changed the playlist note text from "SpotDL" to "FabDL". 
- Fixed gallery DOM id usage from `galery` to `gallery` and adjusted the context-menu prevention selector accordingly.

### Testing
- Started a local static server with `python -m http.server 8000` and opened the page with a Playwright script to generate a screenshot, which completed successfully and produced `artifacts/index-streaming.png`. 
- No unit tests were added; changes are limited to `index.html` and were smoke-tested via the served page and screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a1400e6d8832e95fe21a9c3757ea1)